### PR TITLE
Change keycode of "半角/全角" key on JIS keyboard

### DIFF
--- a/configurator/index.html
+++ b/configurator/index.html
@@ -62,7 +62,7 @@ firmware used under permission from Truly Ergonomic
 	<div class="row">
 		<div class="main">
 			<div><kbd id="grave" class="ansi-iso" data-u="35">`~</kbd
-				><kbd id="hankaku" class="dark jis-only" data-u="94">半角</kbd
+				><kbd id="hankaku" class="dark jis-only" data-u="35">`~</kbd
 				><kbd data-u="1E">1!</kbd
 				><kbd data-u="1F">2@</kbd
 				><kbd data-u="20">3#</kbd


### PR DESCRIPTION
Differently from USB HID keycode definition, in most JIS keyboards, keycode of "半角/全角" key is configured as "0x35", which is same to "`~" key.
Using Keyboard LANG 5 ("半角/全角" key on USB HID keycode list) is not in common.
